### PR TITLE
Add support for different image types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-react-screenshot",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "hook which allows to create screenshots",
   "author": "vre2h",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import html2canvas from 'html2canvas'
  * hook for creating screenshot from html node
  * @returns {HookReturn}
  */
-const useScreenshot = () => {
+const useScreenshot = ({ type, quality } = {}) => {
   const [image, setImage] = useState(null)
   const [error, setError] = useState(null)
   /**
@@ -44,7 +44,7 @@ const useScreenshot = () => {
           cropPositionTop,
         )
 
-        const base64Image = croppedCanvas.toDataURL()
+        const base64Image = croppedCanvas.toDataURL(type, quality)
 
         setImage(base64Image)
         return base64Image


### PR DESCRIPTION
As per issue [#1 Parameterise useScreenshot for alternate file types e.g. jpg](https://github.com/vre2h/use-react-screenshot/issues/1). I wanted to output a jpg not a png.  The canvas [toDataURL() API](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL) supports this feature but it is not exposed in the useScreenshot() API.  This pull request simply adds an optional object parameter and passes the input to toDataURL.  User is still responsible for naming the output file extension correctly.  A number of presets may be helpful but could easily be defined for reuse by the consumer.