### PR TITLE
Allow options to be passed to takeScreenShot

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,11 +21,11 @@ const useScreenshot = ({ type, quality } = {}) => {
    * convert html node to image
    * @param {HTMLElement} node
    */
-  const takeScreenShot = (node) => {
+  const takeScreenShot = (node, options = {}) => {
     if (!node) {
       throw new Error('You should provide correct html node.')
     }
-    return html2canvas(node)
+    return html2canvas(node, options)
       .then((canvas) => {
         const croppedCanvas = document.createElement('canvas')
         const croppedCanvasContext = croppedCanvas.getContext('2d')


### PR DESCRIPTION
Allows options to be passed through to `html2canvas`, for example, to capture the full page by passing `windowHeight`.