### PR TITLE
 Update React Peer Dependency to ^18.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docs": "npx jsdoc --readme ./README.md --destination ./docs src/"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
+    "react": "^18.2.0",
     "html2canvas": "^1.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
**Title**: Update React Peer Dependency to ^18.0.2

**Body**:

**Summary**
This Pull Request updates the peer dependency for React to allow compatibility with the latest stable release, version 18.0.2. The change expands the peer dependency range to include all minor and patch updates within the 18.x.x series.

**Motivation**
Recent advancements and features introduced in React 18.x.x are becoming widely adopted, and many projects are in the process of updating. However, users of the current version of this package are facing compatibility warnings due to the existing peer dependency specification which is locked to React 17.x.x. This update facilitates a smoother integration for projects that have transitioned to React 18, enhancing developer experience and adoption.

**Changes**
Modified the peerDependencies entry for react in package.json from "^17.0.2" to "^18.0.2".
Ensured that the peer dependency for react-dom (if present) is also updated accordingly to maintain compatibility.
Testing
A comprehensive test suite has been run against the updated peer dependency range, ensuring no regressions in functionality. Additionally, manual testing was conducted in a React 18.0.2 environment to validate the real-world functionality of the package.

**Impact**
No breaking changes are introduced with this PR, and the package continues to function as expected in environments using React 17.x.x due to the backward-compatible nature of React 18. Projects using React 18 can now install the package without warnings without having to force --legacy-per-dep to ignore all the peer dependencies.

Additional Considerations
It's recommended for consumers of this package to review their project's compatibility with React 18 and the changes it introduces. This PR does not enforce an upgrade to React 18; it merely adds the option for those who have upgraded.

